### PR TITLE
feat(infra): EPIC6 — Docker multi-stage build + compose + docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# noema-agent Dockerfile
+# Multi-stage build: minimal production image + isolated dev/test layer
+#
+# Stages:
+#   builder  — installs all deps into a venv (prod + dev)
+#   prod     — copies venv + app only; no test deps, no build tools
+#   dev      — extends prod with test deps; used for local dev and CI
+#
+# Usage:
+#   Production:  docker build --target prod -t noema-agent:prod .
+#   Dev/test:    docker build --target dev  -t noema-agent:dev  .
+#   Default:     docker build -t noema-agent . (builds prod)
+
+# ── Stage 1: builder ──────────────────────────────────────────────────────────
+FROM python:3.11-slim AS builder
+
+WORKDIR /build
+
+# Install pip + venv tooling only
+RUN pip install --no-cache-dir --upgrade pip
+
+# Copy dependency manifests first for layer caching
+COPY requirements.txt requirements-dev.txt ./
+
+# Create venv and install prod deps
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir -r requirements.txt
+
+
+# ── Stage 2: prod ─────────────────────────────────────────────────────────────
+FROM python:3.11-slim AS prod
+
+# Non-root user for minimal attack surface
+RUN addgroup --system noema && adduser --system --ingroup noema noema
+
+WORKDIR /app
+
+# Copy venv from builder (no build tools, no pip)
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Copy application source only
+COPY app/ ./app/
+
+# Drop to non-root
+USER noema
+
+# Health check: lightweight GET /health
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]
+
+
+# ── Stage 3: dev ──────────────────────────────────────────────────────────────
+FROM prod AS dev
+
+# Switch back to root to install dev deps
+USER root
+
+COPY requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+# Copy test files
+COPY tests/ ./tests/
+COPY test_api.py test_compliance.py ./
+
+# Back to non-root for runtime
+USER noema
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+# noema-agent docker-compose
+#
+# Services:
+#   agent      — production image (default)
+#   agent-dev  — dev image with hot-reload and test deps mounted
+#
+# Usage:
+#   Start prod:    docker compose up agent
+#   Start dev:     docker compose up agent-dev
+#   Run tests:     docker compose run --rm agent-dev pytest tests/ -v
+#   Health check:  curl http://localhost:8000/health
+
+services:
+  agent:
+    build:
+      context: .
+      target: prod
+    image: noema-agent:prod
+    container_name: noema-agent
+    ports:
+      - "8000:8000"
+    environment:
+      - MAX_PAYLOAD_BYTES=65536
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  agent-dev:
+    build:
+      context: .
+      target: dev
+    image: noema-agent:dev
+    container_name: noema-agent-dev
+    ports:
+      - "8001:8000"
+    environment:
+      - MAX_PAYLOAD_BYTES=65536
+    volumes:
+      # Hot-reload: mount source so changes reflect without rebuild
+      - ./app:/app/app
+      - ./tests:/app/tests
+    restart: "no"

--- a/docs/EPIC6_Infrastructure.md
+++ b/docs/EPIC6_Infrastructure.md
@@ -1,0 +1,110 @@
+# EPIC 6 — Infrastructure Hardening
+
+- **Issue**: noema-agent #9
+- **DoD**: Docker reproducible / Build documented / Minimal runtime footprint
+- **Date**: 2026-05-15
+
+---
+
+## 構成概要
+
+```
+noema-agent/
+├── Dockerfile             # Multi-stage build (builder / prod / dev)
+├── docker-compose.yml     # Service definitions (agent / agent-dev)
+├── requirements.txt       # Prod deps only (fastapi, uvicorn, pydantic)
+├── requirements-dev.txt   # Dev/test deps (pytest, httpx, requests)
+└── docs/
+    └── EPIC6_Infrastructure.md
+```
+
+---
+
+## Docker ビルド
+
+### Production
+
+```bash
+# イメージビルド
+docker build --target prod -t noema-agent:prod .
+
+# 起動
+docker run -p 8000:8000 noema-agent:prod
+
+# または compose で
+docker compose up agent
+```
+
+### Dev / テスト
+
+```bash
+# Dev イメージビルド
+docker build --target dev -t noema-agent:dev .
+
+# hot-reload 付き起動 (port 8001)
+docker compose up agent-dev
+
+# テスト実行
+docker compose run --rm agent-dev pytest tests/ -v
+```
+
+---
+
+## Multi-stage 設計
+
+| Stage | ベース | 内容 | 用途 |
+|---|---|---|---|
+| `builder` | python:3.11-slim | venv 作成、prod deps インストール | 中間 |
+| `prod` | python:3.11-slim | venv + app のみ。非 root ユーザー | 本番 |
+| `dev` | prod (継承) | + dev deps + tests mount | 開発/CI |
+
+**prod イメージに含まれないもの:** pytest / httpx / requests / build tools / pip
+
+---
+
+## 環境変数
+
+| 変数 | デフォルト | 説明 |
+|---|---|---|
+| `MAX_PAYLOAD_BYTES` | `65536` (64KB) | constraint_engine の payload size 上限 |
+
+---
+
+## ヘルスチェック
+
+```bash
+curl http://localhost:8000/health
+# {"status": "healthy", "executor": "ready", "supported_tasks": ["echo"]}
+
+curl http://localhost:8000/
+# {"service": "noema-agent", "version": "3.0.0", ...}
+```
+
+---
+
+## セキュリティ方針
+
+- 非 root ユーザー (`noema`) で実行
+- prod イメージにテストコード・テスト依存物なし
+- `python:3.11-slim` ベース (不要なシステムパッケージを排除)
+- `--no-access-log` で prod ログに request path を残さない (privacy)
+
+---
+
+## EPIC 2 との接続
+
+`MAX_PAYLOAD_BYTES` 環境変数は `app/constraint_engine.py` が読み取る:
+
+```python
+_MAX_PAYLOAD_BYTES = int(os.environ.get("MAX_PAYLOAD_BYTES", 65_536))
+```
+
+Docker 経由で constraint limit を外部から制御可能。
+
+---
+
+## 既知の制限 (EPIC 6 スコープ外)
+
+- `_NETWORK_DEPENDENT_TASK_TYPES` が現状空集合。実用的なタスクタイプが追加されたタイミングで埋めること (EPIC 2 チェック時の指摘)
+- TLS / reverse proxy 設定は本 EPIC のスコープ外
+- CI パイプラインへの組み込みは別途

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Development and test dependencies
+# NOT included in the production Docker image
+pytest>=8.0.0
+httpx>=0.27.0
+requests>=2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
+# Production dependencies only
+# Installed in the prod Docker stage
 fastapi>=0.115.0
 uvicorn[standard]>=0.32.0
 pydantic>=2.10.3
-pytest>=8.0.0
-httpx>=0.27.0
-requests>=2.31.0


### PR DESCRIPTION
## EPIC 6 — Infrastructure Hardening\n\nCloses noema-agent #9\n\n### DoD チェック\n\n- [x] **Docker reproducible** — multi-stage Dockerfile (builder/prod/dev)、`docker compose up agent` 一発で起動\n- [x] **Build documented** — `docs/EPIC6_Infrastructure.md` に build/run/test 手順、設計根拠、既知制限を記載\n- [x] **Minimal runtime footprint** — prod stage は `app/` + venv のみ。pytest/httpx/requests は dev stage にのみ存在。非 root ユーザー `noema` で実行\n\n### 変更ファイル\n\n| ファイル | 内容 |\n|---|---|\n| `Dockerfile` | 3-stage multi-stage build |\n| `docker-compose.yml` | prod (port 8000) + dev (port 8001, volume mount) |\n| `requirements.txt` | prod deps のみに絞る (fastapi/uvicorn/pydantic) |\n| `requirements-dev.txt` | 新規: test deps を分離 (pytest/httpx/requests) |\n| `docs/EPIC6_Infrastructure.md` | build/run ドキュメント |\n\n### クイックスタート\n\n```bash\n# Prod\ndocker compose up agent\ncurl http://localhost:8000/health\n\n# Tests\ndocker compose run --rm agent-dev pytest tests/ -v\n```\n\n### 注意点\n\n`requirements.txt` から test deps を分離したため、ローカルで `pip install -r requirements.txt` だけだと pytest が入らない。`pip install -r requirements-dev.txt` の追加が必要。\n